### PR TITLE
[Hotfix] Cast Timestamp to DateTime

### DIFF
--- a/lib/task/domain/models/task.dart
+++ b/lib/task/domain/models/task.dart
@@ -11,7 +11,7 @@ class Task {
   Task.create(String this.id, Map<String, dynamic> map) {
     title = map['title'];
     notes = map['notes'];
-    due = map['due'];
+    due = map['due']?.toDate();
     available = map['available'];
     completed = map['completed'];
     reward = map['reward'];


### PR DESCRIPTION
# Overview

Bug: There's no casting for `due` prop in `Task` domain model.
Solution: Add casting to `DateTime` with `?.toDate()`.