### PR TITLE
[Housekeeping] Firestore Instance Initialization

### DIFF
--- a/lib/data/task_repository.dart
+++ b/lib/data/task_repository.dart
@@ -2,9 +2,12 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 import '../constants/database_collection.dart';
 import '../domain/models/task.dart';
+import '../utils/services/firestore.dart';
 
 /// Repository for task [FirebaseFirestore] collection.
 class TaskRepository {
+  final _firestore = Firestore.user();
+
   /// Find all task data.
   Future<List<Task>> findAll({required String userId}) async {
     QuerySnapshot<Map<String, dynamic>> found =
@@ -44,8 +47,5 @@ class TaskRepository {
 
   /// Create [FirebaseFirestore] instance for task collection.
   CollectionReference<Map<String, dynamic>> _tasks({required String userId}) =>
-      FirebaseFirestore.instance
-          .collection(dUser)
-          .doc(userId)
-          .collection(dTask);
+      _firestore.doc(userId).collection(dTask);
 }

--- a/lib/data/user_repository.dart
+++ b/lib/data/user_repository.dart
@@ -1,10 +1,12 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-import '../constants/database_collection.dart';
 import '../domain/models/user.dart';
+import '../utils/services/firestore.dart';
 
 /// Repository for user [FirebaseFirestore] collection.
 class UserRepository {
+  final _firestore = Firestore.user();
+
   /// Find all user data.
   Future<List<User>> findAllWhereEqualTo({
     required String field,
@@ -36,6 +38,5 @@ class UserRepository {
   }
 
   /// Create [FirebaseFirestore] instance for user collection.
-  CollectionReference<Map<String, dynamic>> _users() =>
-      FirebaseFirestore.instance.collection(dUser);
+  CollectionReference<Map<String, dynamic>> _users() => _firestore;
 }

--- a/lib/utils/services/firestore.dart
+++ b/lib/utils/services/firestore.dart
@@ -1,0 +1,10 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../constants/database_collection.dart';
+
+/// [FirebaseFirestore] basic instances.
+class Firestore {
+  /// Get instance for user collection.
+  static CollectionReference<Map<String, dynamic>> user() =>
+      FirebaseFirestore.instance.collection(dUser);
+}


### PR DESCRIPTION
# Overview

Lessen the number of Firestore instance being created by creating a class to create root collection instances and directly saved it locally in class variable.